### PR TITLE
Add human readable timestamps.

### DIFF
--- a/liftoff/config.py
+++ b/liftoff/config.py
@@ -105,7 +105,7 @@ def parse_args(strict: bool = True) -> Namespace:
         dest="out_dir"
     )
     arg_parser.add_argument("--ppid", type=int, dest="__ppid")
-    arg_parser.add_argument("--timestamp", type=int, dest="__timestamp")
+    arg_parser.add_argument("--timestamp", type=str, dest="__timestamp")
 
     if strict:
         return arg_parser.parse_args()

--- a/liftoff/liftoff_utils.py
+++ b/liftoff/liftoff_utils.py
@@ -42,6 +42,12 @@ def parse_args() -> Args:
     arg_parser.add_argument(
         "-d", "--results-dir", dest="results_dir", default="results",
         help="Results directory (default: ./results)")
+    arg_parser.add_argument(
+        '--timestamp_fmt',
+        type=str,
+        dest="timestamp_fmt",
+        default="%Y%b%d-%H%M%S",
+        help="Default timestamp format.")
 
     return arg_parser.parse_args()
 
@@ -387,8 +393,10 @@ def abort() -> None:
     params = [args.timestamp, args.experiment, args.results_dir]
     experiments = get_running_liftoffs(*params)
     if len(experiments) > 1 and not args.all:
-        latest_tmstmp = max(e.timestamp for e in experiments)
-        to_kill = [latest_tmstmp]
+        tmstmps = [datetime.datetime.strptime(e.timestamp, args.timestamp_fmt)
+                   for e in experiments]
+        latest_tmstmp = max(tmstmps)
+        to_kill = [f"{latest_tmstmp:{args.timestamp_fmt:s}}"]
     else:
         to_kill = [e.timestamp for e in experiments]
 


### PR DESCRIPTION
Changes the old `time.time()` timestamps in the results folder names to a human readable format.
Sorting works also. Added `timestamp_fmt` argument which allows for different timestamp format. There's a gotcha though if you change the default: you have to know the timestamp format you used when you launched an experiment if you want to resume it.

Example: `1542887916_default` is now `2018Nov22-135836_default`.