### PR TITLE
liftoff-clean can now remove all the files produced by an experiment.

### DIFF
--- a/liftoff/common/__init__.py
+++ b/liftoff/common/__init__.py
@@ -1,0 +1,10 @@
+LIFTOFF_FILES = [
+    ".__leaf",
+    ".__lock",
+    ".__start",
+    ".__end",
+    ".__crash",
+    ".__journal",
+    "cfg.yaml",
+]
+

--- a/liftoff/common/options_parser.py
+++ b/liftoff/common/options_parser.py
@@ -182,6 +182,14 @@ class OptionParser:
             help="Script to be executed with all those configs.",
         )
 
+    def _add_clean_all(self) -> None:
+        self.arg_parser.add_argument(
+            "--clean-all",
+            action="store_true",
+            dest="clean_all",
+            help="Clean *all* the files an experiment run produced.",
+        )
+
     def _add_timestamp_fmt(self) -> None:
         default_value = self.liftoff_config.get("timestamp_fmt")
         if default_value is None:


### PR DESCRIPTION
`liftoff-clean <results_path> --clean-all` removes all the non-liftoff files it finds if the run was not successful. 

@tudor-berariu this feature might be in conflict with a setting in which the experiment saves checkpoints and is able to resume from a checkpoint if crashed? 