### PR TITLE
Add the option to shuffle the runs.

### DIFF
--- a/liftoff/common/options_parser.py
+++ b/liftoff/common/options_parser.py
@@ -310,3 +310,11 @@ class OptionParser:
             default=0,
             help="Stop if max runs have been exceeded. (default 0 - run all).",
         )
+
+    def _add_shuffle(self) -> None:
+        self.arg_parser.add_argument(
+            "--shuffle",
+            action="store_true",
+            dest="shuffle",
+            help="Makes sure the runs are launched randomly.",
+        )


### PR DESCRIPTION
Right now liftoff first launches all the runs in an experiment before moving to another. Sometimes you might want to make sure the runs are launched at random, across experiments.

Usage:

```python
liftoff script.py /path/to/exp --shuffle
```